### PR TITLE
Adjusted chown for newly created file (and folders).

### DIFF
--- a/O365SharedActivator
+++ b/O365SharedActivator
@@ -2,7 +2,7 @@
 #set -x
 
 TOOL_NAME="Microsoft Office 365 Mac Shared Subscription Activator"
-TOOL_VERSION="1.5"
+TOOL_VERSION="1.6"
 
 ## Copyright (c) 2018 Microsoft Corp. All rights reserved.
 ## Scripts are not supported under any Microsoft standard support program or service. The scripts are provided AS IS without warranty of any kind.
@@ -41,6 +41,7 @@ function ShowUsage {
 	echo "Example: O365SharedActivator --master                (Sets the current users subscription as the master license for this computer)"
 	echo "Example: O365SharedActivator --serialize             (Allows the logged-on user to consume the master license)"
 	echo "Example: O365SharedActivator --serialize --user:$3   (Used to serialize user accounts when running as a Jamf login script)"
+	echo "Example: O365SharedActivator --filltemplate          (Allows new users to consume the master license)"
 	echo "Example: O365SharedActivator --deactivate            (Removes the master license from this computer)"
 	echo
 	exit 0
@@ -78,6 +79,15 @@ function CopyMasterLicense {
 	fi
 	cp -f "$SHAREDLICENSE" "$O365SUBMAIN"
 	sudo chown -R "$USER" "$O365PRODUCT"
+}
+
+function FillTemplateWithMasterLicense {
+	# Fill excisting users
+	for TEMPLATELANG in /System/Library/User\ Template/*; do
+	# Copies the master license to the user template
+		mkdir -p "$TEMPLATELANG/Library/Group Containers/UBF8T346G9.Office"
+		cp -f "$SHAREDLICENSE" "$TEMPLATELANG/Library/Group Containers/UBF8T346G9.Office/"
+	done
 }
 
 function RemoveMasterLicense {
@@ -124,6 +134,10 @@ else
 	;;
 	--serialize|-s)
 	SERIALIZE=true
+	shift # past argument
+	;;
+	--filltemplate)
+	FILLTEMPLATE=true
 	shift # past argument
 	;;
 	--user:*|-u:*)
@@ -186,7 +200,15 @@ elif [ $SERIALIZE ]; then
 	else
 		echo "WARNING: The master license does not exist on this computer."
 	fi
+
+elif [ $FILLTEMPLATE ]; then
+	MASTERPRESENT=$(DetectLicense "$SHAREDLICENSE")
+	if [ "$MASTERPRESENT" == "1" ]; then
+		FillTemplateWithMasterLicense
+		echo "Future users that will be created has been serialized with the master license from this computer."
+	else
+		echo "WARNING: The master license does not exist on this computer."
+	fi
 fi
-	
 
 exit 0

--- a/O365SharedActivator
+++ b/O365SharedActivator
@@ -2,7 +2,7 @@
 #set -x
 
 TOOL_NAME="Microsoft Office 365 Mac Shared Subscription Activator"
-TOOL_VERSION="1.4"
+TOOL_VERSION="1.5"
 
 ## Copyright (c) 2018 Microsoft Corp. All rights reserved.
 ## Scripts are not supported under any Microsoft standard support program or service. The scripts are provided AS IS without warranty of any kind.
@@ -64,7 +64,6 @@ function SetLicenseAsMaster {
 	else
 		if [ ! -d "/Library/Application Support/Microsoft/Office365" ]; then
 			sudo mkdir -p "/Library/Application Support/Microsoft/Office365"
-			sudo chown -R $USER: "$HOME/Library/Group Containers"
 		fi
 		sudo cp -f "$O365SUBMAIN" "$SHAREDLICENSE"
 	fi
@@ -74,8 +73,10 @@ function CopyMasterLicense {
 # Copies the master license to the current users folder
 	if [ ! -d "$HOME/Library/Group Containers/UBF8T346G9.Office" ]; then
 		mkdir -p "$HOME/Library/Group Containers/UBF8T346G9.Office"
+		sudo chown -R "$USER" "$HOME/Library/Group Containers"
 	fi
 	cp -f "$SHAREDLICENSE" "$O365SUBMAIN"
+	sudo chown -R "$USER" "$O365SUBMAIN"
 }
 
 function RemoveMasterLicense {

--- a/O365SharedActivator
+++ b/O365SharedActivator
@@ -17,7 +17,8 @@ TOOL_VERSION="1.5"
 function SetConstants {
 # Constants
 	SHAREDLICENSE="/Library/Application Support/Microsoft/Office365/com.microsoft.Office365.plist"
-	O365SUBMAIN="$HOME/Library/Group Containers/UBF8T346G9.Office/com.microsoft.Office365.plist"
+	O365PRODUCT="$HOME/Library/Group Containers/UBF8T346G9.Office"
+	O365SUBMAIN="$O365PRODUCT/com.microsoft.Office365.plist"
 }
 
 function GetHomeFolder {
@@ -76,7 +77,7 @@ function CopyMasterLicense {
 		sudo chown -R "$USER" "$HOME/Library/Group Containers"
 	fi
 	cp -f "$SHAREDLICENSE" "$O365SUBMAIN"
-	sudo chown -R "$USER" "$O365SUBMAIN"
+	sudo chown -R "$USER" "$O365PRODUCT"
 }
 
 function RemoveMasterLicense {

--- a/O365SharedActivator
+++ b/O365SharedActivator
@@ -72,8 +72,8 @@ function SetLicenseAsMaster {
 
 function CopyMasterLicense {
 # Copies the master license to the current users folder
-	if [ ! -d "$HOME/Library/Group Containers/UBF8T346G9.Office" ]; then
-		mkdir -p "$HOME/Library/Group Containers/UBF8T346G9.Office"
+	if [ ! -d "$O365PRODUCT" ]; then
+		mkdir -p "$O365PRODUCT"
 		sudo chown -R "$USER" "$HOME/Library/Group Containers"
 	fi
 	cp -f "$SHAREDLICENSE" "$O365SUBMAIN"


### PR DESCRIPTION
Removed chown after copy of master license (these permissions should be correct already, since we are copying from that location)
Added path for product license
Added chown for product license path and product license file. So apps does not crash if user had not run them before.
Increased version to 1.5